### PR TITLE
Fixed language bug in json response

### DIFF
--- a/src/main/java/app/mappers/DishMapper.java
+++ b/src/main/java/app/mappers/DishMapper.java
@@ -63,8 +63,8 @@ public class DishMapper
         return new MenuDishDTO(
             dish.getId(),
             dish.getNameDA(),
-            dish.getDescriptionDA(),
             dish.getNameEN(),
+            dish.getDescriptionDA(),
             dish.getDescriptionEN(),
             dish.hasTranslation(),
             allergens


### PR DESCRIPTION
## Fix language mapping in DishMapper

This PR fixes an issue where Danish and English description fields were incorrectly mapped in the JSON response.

### What was wrong
- English description field was returning the Danish value

### What was changed
- Corrected field mapping in `DishMapper`
- Ensured proper separation of `descriptionDA` and `descriptionEN`

### Result
- JSON response now returns correct language-specific descriptions